### PR TITLE
Fixed the positioning issue for chat window

### DIFF
--- a/src/client/game/js/ng/directives/chat.js
+++ b/src/client/game/js/ng/directives/chat.js
@@ -29,7 +29,7 @@ IronbaneApp
             var width = Math.floor($(window).width() * 0.4);
             el.css({
                 width: width + 'px',
-                left: ($(window).width() - width - 8) + 'px',
+                right: '8px',
                 top: '8px'
             });
 


### PR DESCRIPTION
Chat window was based on a static left alignment when it's positioned on the top right side, so instead of using left: window blah we just say right: '8px'; so it will automatically stay to the right.
