### PR TITLE
Making whisper instructions visible

### DIFF
--- a/src/client/game/js/ng/help/help_chat.html
+++ b/src/client/game/js/ng/help/help_chat.html
@@ -1,6 +1,9 @@
 <div>
+    <!--
+    at 0.4.6, only the definitionn list is displaying on /chathelp
     <p>You may start entering a command by pressing the / key. It will open your chat.</p>
     <p>Also, you can use @ to start a targetted message, player name or room name.</p>
+    -->
     <dl>
         <dt>/join</dt>
         <dd>(Join/create a room)</dd>
@@ -18,5 +21,9 @@
         <dd>(See where your buddies hangout)</dd>
         <dt>/dice number</dt>
         <dd>(Number is optional)</dd>
+        <dt>@playername message</dt>
+        <dd>(Send private message)</dd>
+        <dt>@roomname message</dt>
+        <dd>(Send private message to room)</dd>
     </dl>
 </div>


### PR DESCRIPTION
At 0.4.6 tag, at least, only the <dl> portion of the
instructions here are visible.  I commented out the
part that doesn't display anyway, and put equivalent
info into the dl.

This is to replace the p.r. #412
